### PR TITLE
Hide top bar

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -1727,9 +1727,14 @@ static void refreshViewIfNeeded(UIView *view, NSTimeInterval delay) {
     %orig;
 
     if (isHomeTimelineContainer(self)) {
-        for (UIGestureRecognizer *gesture in self.view.gestureRecognizers) {
-            if ([gesture isKindOfClass:[UIPanGestureRecognizer class]]) {
-                gesture.enabled = NO; // désactive le swipe gauche-droite
+        // Forcer Following
+        [self setSelectedIndex:1];
+
+        // Bloquer le swipe horizontal en désactivant le scroll sur les UIScrollView enfants
+        for (UIView *subview in self.view.subviews) {
+            if ([subview isKindOfClass:[UIScrollView class]]) {
+                UIScrollView *scrollView = (UIScrollView *)subview;
+                scrollView.scrollEnabled = NO; // empêche tout swipe
             }
         }
     }

--- a/Tweak.x
+++ b/Tweak.x
@@ -4132,28 +4132,3 @@ static NSBundle *BHBundle() {
         }
     }
 %end
-
-%hook T1GenericSettingsViewController // ou la classe de ton menu de gauche
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-
-    UITableViewCell *cell = %orig(indexPath);
-
-    @try {
-        NSString *title = nil;
-        if ([cell respondsToSelector:@selector(textLabel)]) {
-            title = cell.textLabel.text;
-        }
-
-        if (title && ([title isEqualToString:@"Video"] || [title isEqualToString:@"Vidéos"])) {
-            cell.hidden = YES;            // cache la cellule
-            cell.frame = CGRectZero;       // évite l’espace vide
-            cell.contentView.alpha = 0.0;  // optionnel, pour être sûr
-        }
-
-    } @catch (NSException *e) {
-        NSLog(@"[BHTwitter] Error hiding Video tab: %@", e);
-    }
-
-    return cell;
-}
-%end

--- a/Tweak.x
+++ b/Tweak.x
@@ -25,6 +25,14 @@
 #import <Preferences/PSListController.h>
 #import <Preferences/PSSpecifier.h>
 #import "ModernSettingsViewController.h"
+#import "T1PlayerMediaEntitySessionProducible.h"
+#import "TFSTwitterEntityMediaVideoVariant.h"
+#import "JGProgressHUD.h"
+#import "TFNActiveTextItem.h"
+#import "TFNAttributedTextModel.h"
+#import "TFNMenuSheetViewController.h"
+#import "BHDownload.h"
+#import "MediaInformation.h"
 
 @class T1SettingsViewController;
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -1723,6 +1723,8 @@ static void refreshViewIfNeeded(UIView *view, NSTimeInterval delay) {
 }
 
 // Ensure proper view loading and prevent white screen, only on homepage
+%hook TFNScrollingSegmentedViewController
+
 - (void)viewDidLoad {
     %orig;
 
@@ -1730,62 +1732,58 @@ static void refreshViewIfNeeded(UIView *view, NSTimeInterval delay) {
         // Forcer Following
         [self setSelectedIndex:1];
 
-        // Bloquer le swipe horizontal en désactivant le scroll sur les UIScrollView enfants
-        for (UIView *subview in self.view.subviews) {
-            if ([subview isKindOfClass:[UIScrollView class]]) {
-                UIScrollView *scrollView = (UIScrollView *)subview;
-                scrollView.scrollEnabled = NO; // empêche tout swipe
-            }
-        }
+        // Désactiver le swipe horizontal
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            BH_EnumerateSubviewsRecursively(self.view, ^(UIView *subview) {
+                if ([subview isKindOfClass:[UIScrollView class]]) {
+                    UIScrollView *sv = (UIScrollView *)subview;
+                    if (sv.isPagingEnabled) {
+                        sv.pagingEnabled = NO;
+                    }
+                    sv.alwaysBounceHorizontal = NO;
+                    sv.showsHorizontalScrollIndicator = NO;
+                    if (sv.contentSize.width > CGRectGetWidth(sv.frame) + 1.0) {
+                        sv.contentSize = CGSizeMake(CGRectGetWidth(sv.frame), sv.contentSize.height);
+                    }
+                }
+
+                for (UIGestureRecognizer *g in subview.gestureRecognizers ?: @[]) {
+                    if ([g isKindOfClass:[UIPanGestureRecognizer class]]) {
+                        NSString *desc = NSStringFromClass([g.view class]);
+                        NSString *gdesc = [g description] ?: @"";
+                        if ([desc containsString:@"Page"] ||
+                            [gdesc.lowercaseString containsString:@"page"] ||
+                            [gdesc.lowercaseString containsString:@"paging"]) {
+                            g.enabled = NO;
+                        }
+                    }
+                }
+            });
+
+            refreshViewIfNeeded(self.view, 0.05);
+        });
     }
 }
 
-- (void)viewDidLoad {
+%end
+
+// Additional fix for view appearance to ensure content loads properly, only on homepage
+- (void)viewDidAppear:(BOOL)animated {
     %orig;
 
-    if (!isHomeTimelineContainer(self)) return;
+    if (isHomeTimelineContainer(self)) {
+        [self setSelectedIndex:1];
+        refreshViewIfNeeded(self.view, 0.1);
+    }
+}
 
-    // Forcer Following
-    [self setSelectedIndex:1];
-
-    // Petit délai pour que la hiérarchie de vues soit en place
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        // Parcours récursif de toutes les sous-vues
-        BH_EnumerateSubviewsRecursively(self.view, ^(UIView *subview) {
-            if ([subview isKindOfClass:[UIScrollView class]]) {
-                UIScrollView *sv = (UIScrollView *)subview;
-
-                // Si c'est une scrollView paginée (le swipe ForYou/Following), on la neutralise
-                if (sv.isPagingEnabled) {
-                    sv.pagingEnabled = NO;
-                }
-
-                sv.alwaysBounceHorizontal = NO;
-                sv.showsHorizontalScrollIndicator = NO;
-
-                // Réduction du contentSize si trop large (empêche le swipe horizontal)
-                if (sv.contentSize.width > CGRectGetWidth(sv.frame) + 1.0) {
-                    sv.contentSize = CGSizeMake(CGRectGetWidth(sv.frame), sv.contentSize.height);
-                }
-            }
-
-            // Désactiver les gestures "page" ou "paging"
-            for (UIGestureRecognizer *g in subview.gestureRecognizers ?: @[]) {
-                if ([g isKindOfClass:[UIPanGestureRecognizer class]]) {
-                    NSString *desc = NSStringFromClass([g.view class]);
-                    NSString *gdesc = [g description] ?: @"";
-
-                    if ([desc containsString:@"Page"] ||
-                        [gdesc.lowercaseString containsString:@"page"] ||
-                        [gdesc.lowercaseString containsString:@"paging"]) {
-                        g.enabled = NO;
-                    }
-                }
-            }
-        });
-
-        refreshViewIfNeeded(self.view, 0.05);
-    });
+// Ensure selected index is always the Following tab, only on homepage
+- (void)setSelectedIndex:(NSInteger)index {
+    if (isHomeTimelineContainer(self)) {
+        %orig(1); // Always set to Following tab (index 1)
+    } else {
+        %orig(index); // Use the original index for other interfaces
+    }
 }
 %end
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -433,6 +433,86 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
         }
     }
 }
+
+- (void)setTabBarHidden:(BOOL)arg1 withDuration:(CGFloat)arg2 {
+    if ([BHTManager stopHidingTabBar]) {
+        return;
+    }
+    
+    return %orig;
+}
+- (void)setTabBarHidden:(BOOL)arg1 {
+    if ([BHTManager stopHidingTabBar]) {
+        return;
+    }
+    
+    return %orig;
+}
+%end
+
+%hook TFNScrollingSegmentedViewController
+// Selectively hide the tab bar only on homepage
+- (BOOL)_tfn_shouldHideLabelBar {
+    // Only hide the label bar in the home timeline
+    if (isHomeTimelineContainer(self)) {
+        return YES;
+    }
+
+    // For all other interfaces, use default behavior
+    return %orig;
+}
+
+// Sets the number of tabs in the sub bar
+- (NSInteger)pagingViewController:(id)arg1 numberOfPagesInSection:(id)arg2 { 
+     return %orig;
+}
+
+// Returns the "Following" tab's view controller for both tabs, but only on homepage
+- (UIViewController *)pagingViewController:(UIViewController *)viewController viewControllerAtIndexPath:(NSIndexPath *)indexPath {
+    if (isHomeTimelineContainer(self)) {
+        // Always use the Following tab (index 1)
+        NSIndexPath *followingIndexPath = [NSIndexPath indexPathForRow:1 inSection:0];
+        return %orig(viewController, followingIndexPath);
+    }
+
+    return %orig(viewController, indexPath);
+}
+
+// Ensure proper view loading and prevent white screen, only on homepage
+- (void)viewDidLoad {
+    %orig;
+
+    if (isHomeTimelineContainer(self)) {
+        [self setSelectedIndex:1];
+    }
+}
+
+// Additional fix for view appearance to ensure content loads properly, only on homepage
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+
+    if (isHomeTimelineContainer(self)) {
+        [self setSelectedIndex:1];
+        refreshViewIfNeeded(self.view, 0.1);
+    }
+}
+
+// Ensure selected index is always the Following tab, only on homepage
+- (void)setSelectedIndex:(NSInteger)index {
+    if (isHomeTimelineContainer(self)) {
+        %orig(1); // Always set to Following tab (index 1)
+    } else {
+        %orig(index); // Use the original index for other interfaces
+    }
+}
+%end
+
+// Fix refresh functionality
+%hook THFTimelineViewController
+- (void)_pullToRefresh:(id)sender {
+    %orig;
+    refreshViewIfNeeded(self.view, 0.5);
+}
 %end
 
 %hook T1DirectMessageConversationEntriesViewController
@@ -1670,15 +1750,6 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
     %orig([BHTManager showScrollIndicator]);
 }
 %end
-
-@interface TFNScrollingSegmentedViewController : UIViewController
-- (void)setSelectedIndex:(NSInteger)index;
-- (NSInteger)selectedIndex;
-@end
-
-@interface THFTimelineViewController : UIViewController
-- (void)_pullToRefresh:(id)sender;
-@end
 
 // start of NFB features
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -1672,18 +1672,8 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
 %end
 
 @interface TFNScrollingSegmentedViewController : UIViewController
-- (void)viewDidLoad {
-    %orig;
-
-    // Si tu veux seulement désactiver le swipe sur la Home Timeline
-    if (isHomeTimelineContainer(self)) {
-        for (UIGestureRecognizer *gesture in self.view.gestureRecognizers) {
-            if ([gesture isKindOfClass:[UIPanGestureRecognizer class]]) {
-                gesture.enabled = NO;
-            }
-        }
-    }
-}
+- (void)setSelectedIndex:(NSInteger)index;
+- (NSInteger)selectedIndex;
 @end
 
 @interface THFTimelineViewController : UIViewController
@@ -1737,7 +1727,11 @@ static void refreshViewIfNeeded(UIView *view, NSTimeInterval delay) {
     %orig;
 
     if (isHomeTimelineContainer(self)) {
-        [self setSelectedIndex:1];
+        for (UIGestureRecognizer *gesture in self.view.gestureRecognizers) {
+            if ([gesture isKindOfClass:[UIPanGestureRecognizer class]]) {
+                gesture.enabled = NO; // désactive le swipe gauche-droite
+            }
+        }
     }
 }
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -33,6 +33,7 @@
 #import "BHDownload.h"
 #import "MediaInformation.h"
 #import "THFTimelineViewController.h"
+#import "TFSTwitterEntityMediaVideoVariant.h"
 
 @class T1SettingsViewController;
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -1740,23 +1740,52 @@ static void refreshViewIfNeeded(UIView *view, NSTimeInterval delay) {
     }
 }
 
-// Additional fix for view appearance to ensure content loads properly, only on homepage
-- (void)viewDidAppear:(BOOL)animated {
+- (void)viewDidLoad {
     %orig;
 
-    if (isHomeTimelineContainer(self)) {
-        [self setSelectedIndex:1];
-        refreshViewIfNeeded(self.view, 0.1);
-    }
-}
+    if (!isHomeTimelineContainer(self)) return;
 
-// Ensure selected index is always the Following tab, only on homepage
-- (void)setSelectedIndex:(NSInteger)index {
-    if (isHomeTimelineContainer(self)) {
-        %orig(1); // Always set to Following tab (index 1)
-    } else {
-        %orig(index); // Use the original index for other interfaces
-    }
+    // Forcer Following
+    [self setSelectedIndex:1];
+
+    // Petit délai pour que la hiérarchie de vues soit en place
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        // Parcours récursif de toutes les sous-vues
+        BH_EnumerateSubviewsRecursively(self.view, ^(UIView *subview) {
+            if ([subview isKindOfClass:[UIScrollView class]]) {
+                UIScrollView *sv = (UIScrollView *)subview;
+
+                // Si c'est une scrollView paginée (le swipe ForYou/Following), on la neutralise
+                if (sv.isPagingEnabled) {
+                    sv.pagingEnabled = NO;
+                }
+
+                sv.alwaysBounceHorizontal = NO;
+                sv.showsHorizontalScrollIndicator = NO;
+
+                // Réduction du contentSize si trop large (empêche le swipe horizontal)
+                if (sv.contentSize.width > CGRectGetWidth(sv.frame) + 1.0) {
+                    sv.contentSize = CGSizeMake(CGRectGetWidth(sv.frame), sv.contentSize.height);
+                }
+            }
+
+            // Désactiver les gestures "page" ou "paging"
+            for (UIGestureRecognizer *g in subview.gestureRecognizers ?: @[]) {
+                if ([g isKindOfClass:[UIPanGestureRecognizer class]]) {
+                    NSString *desc = NSStringFromClass([g.view class]);
+                    NSString *gdesc = [g description] ?: @"";
+
+                    if ([desc containsString:@"Page"] ||
+                        [gdesc.lowercaseString containsString:@"page"] ||
+                        [gdesc.lowercaseString containsString:@"paging"]) {
+                        g.enabled = NO;
+                    }
+                }
+            }
+        });
+
+        refreshViewIfNeeded(self.view, 0.05);
+    });
 }
 %end
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -32,6 +32,7 @@
 #import "TFNMenuSheetViewController.h"
 #import "BHDownload.h"
 #import "MediaInformation.h"
+#import "THFTimelineViewController.h"
 
 @class T1SettingsViewController;
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -1671,6 +1671,15 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
 }
 %end
 
+@interface TFNScrollingSegmentedViewController : UIViewController
+- (void)setSelectedIndex:(NSInteger)index;
+- (NSInteger)selectedIndex;
+@end
+
+@interface THFTimelineViewController : UIViewController
+- (void)_pullToRefresh:(id)sender;
+@end
+
 // start of NFB features
 
 // MARK: Restore Source Labels - This is still pretty experimental and may break. This restores Tweet Source Labels by using an Legacy API. by: @nyaathea

--- a/Tweak.x
+++ b/Tweak.x
@@ -25,7 +25,6 @@
 #import <Preferences/PSListController.h>
 #import <Preferences/PSSpecifier.h>
 #import "ModernSettingsViewController.h"
-#import "T1PlayerMediaEntitySessionProducible.h"
 #import "TFSTwitterEntityMediaVideoVariant.h"
 #import "JGProgressHUD.h"
 #import "TFNActiveTextItem.h"

--- a/Tweak.x
+++ b/Tweak.x
@@ -1723,49 +1723,13 @@ static void refreshViewIfNeeded(UIView *view, NSTimeInterval delay) {
 }
 
 // Ensure proper view loading and prevent white screen, only on homepage
-%hook TFNScrollingSegmentedViewController
-
 - (void)viewDidLoad {
     %orig;
 
     if (isHomeTimelineContainer(self)) {
-        // Forcer Following
         [self setSelectedIndex:1];
-
-        // Désactiver le swipe horizontal
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            BH_EnumerateSubviewsRecursively(self.view, ^(UIView *subview) {
-                if ([subview isKindOfClass:[UIScrollView class]]) {
-                    UIScrollView *sv = (UIScrollView *)subview;
-                    if (sv.isPagingEnabled) {
-                        sv.pagingEnabled = NO;
-                    }
-                    sv.alwaysBounceHorizontal = NO;
-                    sv.showsHorizontalScrollIndicator = NO;
-                    if (sv.contentSize.width > CGRectGetWidth(sv.frame) + 1.0) {
-                        sv.contentSize = CGSizeMake(CGRectGetWidth(sv.frame), sv.contentSize.height);
-                    }
-                }
-
-                for (UIGestureRecognizer *g in subview.gestureRecognizers ?: @[]) {
-                    if ([g isKindOfClass:[UIPanGestureRecognizer class]]) {
-                        NSString *desc = NSStringFromClass([g.view class]);
-                        NSString *gdesc = [g description] ?: @"";
-                        if ([desc containsString:@"Page"] ||
-                            [gdesc.lowercaseString containsString:@"page"] ||
-                            [gdesc.lowercaseString containsString:@"paging"]) {
-                            g.enabled = NO;
-                        }
-                    }
-                }
-            });
-
-            refreshViewIfNeeded(self.view, 0.05);
-        });
     }
 }
-
-%end
 
 // Additional fix for view appearance to ensure content loads properly, only on homepage
 - (void)viewDidAppear:(BOOL)animated {

--- a/Tweak.x
+++ b/Tweak.x
@@ -1672,8 +1672,18 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
 %end
 
 @interface TFNScrollingSegmentedViewController : UIViewController
-- (void)setSelectedIndex:(NSInteger)index;
-- (NSInteger)selectedIndex;
+- (void)viewDidLoad {
+    %orig;
+
+    // Si tu veux seulement désactiver le swipe sur la Home Timeline
+    if (isHomeTimelineContainer(self)) {
+        for (UIGestureRecognizer *gesture in self.view.gestureRecognizers) {
+            if ([gesture isKindOfClass:[UIPanGestureRecognizer class]]) {
+                gesture.enabled = NO;
+            }
+        }
+    }
+}
 @end
 
 @interface THFTimelineViewController : UIViewController

--- a/Tweak.x
+++ b/Tweak.x
@@ -1671,6 +1671,20 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
 }
 %end
 
+@interface TFNScrollingSegmentedViewController : UIViewController
+- (void)setSelectedIndex:(NSInteger)index;
+- (NSInteger)selectedIndex;
+@end
+
+@interface THFTimelineViewController : UIViewController
+- (void)_pullToRefresh:(id)sender;
+@end
+
+// Helper functions to reduce code duplication
+static BOOL isHomeTimelineContainer(UIViewController *viewController) {
+    return [viewController.parentViewController isKindOfClass:NSClassFromString(@"THFHomeTimelineContainerViewController")];
+}
+
 static void refreshViewIfNeeded(UIView *view, NSTimeInterval delay) {
     if (!view) return;
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -25,15 +25,6 @@
 #import <Preferences/PSListController.h>
 #import <Preferences/PSSpecifier.h>
 #import "ModernSettingsViewController.h"
-#import "TFSTwitterEntityMediaVideoVariant.h"
-#import "JGProgressHUD.h"
-#import "TFNActiveTextItem.h"
-#import "TFNAttributedTextModel.h"
-#import "TFNMenuSheetViewController.h"
-#import "BHDownload.h"
-#import "MediaInformation.h"
-#import "THFTimelineViewController.h"
-#import "TFSTwitterEntityMediaVideoVariant.h"
 
 @class T1SettingsViewController;
 
@@ -441,86 +432,6 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
             [tabView setHidden:true];
         }
     }
-}
-
-- (void)setTabBarHidden:(BOOL)arg1 withDuration:(CGFloat)arg2 {
-    if ([BHTManager stopHidingTabBar]) {
-        return;
-    }
-    
-    return %orig;
-}
-- (void)setTabBarHidden:(BOOL)arg1 {
-    if ([BHTManager stopHidingTabBar]) {
-        return;
-    }
-    
-    return %orig;
-}
-%end
-
-%hook TFNScrollingSegmentedViewController
-// Selectively hide the tab bar only on homepage
-- (BOOL)_tfn_shouldHideLabelBar {
-    // Only hide the label bar in the home timeline
-    if (isHomeTimelineContainer(self)) {
-        return YES;
-    }
-
-    // For all other interfaces, use default behavior
-    return %orig;
-}
-
-// Sets the number of tabs in the sub bar
-- (NSInteger)pagingViewController:(id)arg1 numberOfPagesInSection:(id)arg2 { 
-     return %orig;
-}
-
-// Returns the "Following" tab's view controller for both tabs, but only on homepage
-- (UIViewController *)pagingViewController:(UIViewController *)viewController viewControllerAtIndexPath:(NSIndexPath *)indexPath {
-    if (isHomeTimelineContainer(self)) {
-        // Always use the Following tab (index 1)
-        NSIndexPath *followingIndexPath = [NSIndexPath indexPathForRow:1 inSection:0];
-        return %orig(viewController, followingIndexPath);
-    }
-
-    return %orig(viewController, indexPath);
-}
-
-// Ensure proper view loading and prevent white screen, only on homepage
-- (void)viewDidLoad {
-    %orig;
-
-    if (isHomeTimelineContainer(self)) {
-        [self setSelectedIndex:1];
-    }
-}
-
-// Additional fix for view appearance to ensure content loads properly, only on homepage
-- (void)viewDidAppear:(BOOL)animated {
-    %orig;
-
-    if (isHomeTimelineContainer(self)) {
-        [self setSelectedIndex:1];
-        refreshViewIfNeeded(self.view, 0.1);
-    }
-}
-
-// Ensure selected index is always the Following tab, only on homepage
-- (void)setSelectedIndex:(NSInteger)index {
-    if (isHomeTimelineContainer(self)) {
-        %orig(1); // Always set to Following tab (index 1)
-    } else {
-        %orig(index); // Use the original index for other interfaces
-    }
-}
-%end
-
-// Fix refresh functionality
-%hook THFTimelineViewController
-- (void)_pullToRefresh:(id)sender {
-    %orig;
-    refreshViewIfNeeded(self.view, 0.5);
 }
 %end
 
@@ -1757,6 +1668,80 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
 %hook TFNTableView
 - (void)setShowsVerticalScrollIndicator:(BOOL)arg1 {
     %orig([BHTManager showScrollIndicator]);
+}
+%end
+
+static void refreshViewIfNeeded(UIView *view, NSTimeInterval delay) {
+    if (!view) return;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [view setNeedsLayout];
+        [view layoutIfNeeded];
+    });
+}
+
+%hook TFNScrollingSegmentedViewController
+// Selectively hide the tab bar only on homepage
+- (BOOL)_tfn_shouldHideLabelBar {
+    // Only hide the label bar in the home timeline
+    if (isHomeTimelineContainer(self)) {
+        return YES;
+    }
+
+    // For all other interfaces, use default behavior
+    return %orig;
+}
+
+// Sets the number of tabs in the sub bar
+- (NSInteger)pagingViewController:(id)arg1 numberOfPagesInSection:(id)arg2 { 
+     return %orig;
+}
+
+// Returns the "Following" tab's view controller for both tabs, but only on homepage
+- (UIViewController *)pagingViewController:(UIViewController *)viewController viewControllerAtIndexPath:(NSIndexPath *)indexPath {
+    if (isHomeTimelineContainer(self)) {
+        // Always use the Following tab (index 1)
+        NSIndexPath *followingIndexPath = [NSIndexPath indexPathForRow:1 inSection:0];
+        return %orig(viewController, followingIndexPath);
+    }
+
+    return %orig(viewController, indexPath);
+}
+
+// Ensure proper view loading and prevent white screen, only on homepage
+- (void)viewDidLoad {
+    %orig;
+
+    if (isHomeTimelineContainer(self)) {
+        [self setSelectedIndex:1];
+    }
+}
+
+// Additional fix for view appearance to ensure content loads properly, only on homepage
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+
+    if (isHomeTimelineContainer(self)) {
+        [self setSelectedIndex:1];
+        refreshViewIfNeeded(self.view, 0.1);
+    }
+}
+
+// Ensure selected index is always the Following tab, only on homepage
+- (void)setSelectedIndex:(NSInteger)index {
+    if (isHomeTimelineContainer(self)) {
+        %orig(1); // Always set to Following tab (index 1)
+    } else {
+        %orig(index); // Use the original index for other interfaces
+    }
+}
+%end
+
+// Fix refresh functionality
+%hook THFTimelineViewController
+- (void)_pullToRefresh:(id)sender {
+    %orig;
+    refreshViewIfNeeded(self.view, 0.5);
 }
 %end
 

--- a/Tweak.x
+++ b/Tweak.x
@@ -4133,25 +4133,27 @@ static NSBundle *BHBundle() {
     }
 %end
 
-%hook TFNItemsDataViewControllerBackingStore
-- (NSArray *)sections {
-    NSArray *originalSections = %orig;
-    NSMutableArray *filteredSections = [NSMutableArray array];
+%hook T1GenericSettingsViewController // ou la classe de ton menu de gauche
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
 
-    for (id section in originalSections) {
-        // Vérifie que la section contient l’élément "Video"
-        BOOL containsVideo = NO;
-        for (id item in section) {
-            NSString *title = [item valueForKey:@"title"];
-            if ([title isKindOfClass:[NSString class]] && [title isEqualToString:@"Video"]) {
-                containsVideo = YES;
-                break;
-            }
+    UITableViewCell *cell = %orig(indexPath);
+
+    @try {
+        NSString *title = nil;
+        if ([cell respondsToSelector:@selector(textLabel)]) {
+            title = cell.textLabel.text;
         }
-        if (!containsVideo) {
-            [filteredSections addObject:section];
+
+        if (title && ([title isEqualToString:@"Video"] || [title isEqualToString:@"Vidéos"])) {
+            cell.hidden = YES;            // cache la cellule
+            cell.frame = CGRectZero;       // évite l’espace vide
+            cell.contentView.alpha = 0.0;  // optionnel, pour être sûr
         }
+
+    } @catch (NSException *e) {
+        NSLog(@"[BHTwitter] Error hiding Video tab: %@", e);
     }
-    return [filteredSections copy];
+
+    return cell;
 }
 %end

--- a/Tweak.x
+++ b/Tweak.x
@@ -4132,3 +4132,26 @@ static NSBundle *BHBundle() {
         }
     }
 %end
+
+%hook TFNItemsDataViewControllerBackingStore
+- (NSArray *)sections {
+    NSArray *originalSections = %orig;
+    NSMutableArray *filteredSections = [NSMutableArray array];
+
+    for (id section in originalSections) {
+        // Vérifie que la section contient l’élément "Video"
+        BOOL containsVideo = NO;
+        for (id item in section) {
+            NSString *title = [item valueForKey:@"title"];
+            if ([title isKindOfClass:[NSString class]] && [title isEqualToString:@"Video"]) {
+                containsVideo = YES;
+                break;
+            }
+        }
+        if (!containsVideo) {
+            [filteredSections addObject:section];
+        }
+    }
+    return [filteredSections copy];
+}
+%end


### PR DESCRIPTION
Adds the code to hide the top bar and prevent blank pages at launch of app, this being an issue when hiding the top bar. Also prevents swiping left or right to go to the For You page. Best option would be to disable horizontal swipe completely.

There still is to convert this code into an option that can be toggled on or off.