### PR TITLE
Update to macos-14 runner image 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ concurrency:
 jobs:
   build:
     name: Build BHTwitter
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       contents: write
 


### PR DESCRIPTION
This PR will take care of the issue that arises when using the current `macos-13` workflow. This updates the workflow to `macos-14` and building via GitHub Actions will work again. See here for more: https://github.com/actions/runner-images/issues/13046