### PR TITLE
build: Remove Preferences.framework dependency

### DIFF
--- a/BHTManager.m
+++ b/BHTManager.m
@@ -6,7 +6,6 @@
 //
 
 #import "BHTManager.h"
-#import "SettingsViewController.h"
 #import "BHTBundle/BHTBundle.h"
 #import "ModernSettingsViewController.h"
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,9 @@ DEBUG = 1
 
 TWEAK_NAME = BHTwitter
 
-BHTwitter_FILES = Tweak.x ModernSettingsViewController.m $(wildcard *.m BHDownload/*.m BHTBundle/*.m Colours/*.m JGProgressHUD/*.m SAMKeychain/*.m AppIcon/*.m CustomTabBar/*.m ThemeColor/*.m)
+BHTwitter_FILES = Tweak.x ModernSettingsViewController.m $(filter-out SettingsViewController.m, $(wildcard *.m)) $(wildcard BHDownload/*.m BHTBundle/*.m Colours/*.m JGProgressHUD/*.m SAMKeychain/*.m AppIcon/*.m CustomTabBar/*.m ThemeColor/*.m)
 BHTwitter_FRAMEWORKS = UIKit Foundation AVFoundation AVKit CoreMotion GameController VideoToolbox Accelerate CoreMedia CoreImage CoreGraphics ImageIO Photos CoreServices SystemConfiguration SafariServices Security QuartzCore WebKit SceneKit
-BHTwitter_PRIVATE_FRAMEWORKS = Preferences
-BHTwitter_EXTRA_FRAMEWORKS = Cephei CepheiPrefs CepheiUI
+
 BHTwitter_OBJ_FILES = $(shell find lib -name '*.a')
 BHTwitter_LIBRARIES = sqlite3 bz2 c++ iconv z
 BHTwitter_CFLAGS = -fobjc-arc -Wno-deprecated-declarations -Wno-nullability-completeness -Wno-unused-function -Wno-unused-property-ivar -Wno-error

--- a/Tweak.x
+++ b/Tweak.x
@@ -23,8 +23,6 @@
 #import "TWHeaders.h"
 #import "SAMKeychain/SAMKeychain.h"
 #import "CustomTabBar/BHCustomTabBarUtility.h"
-#import <Preferences/PSListController.h>
-#import <Preferences/PSSpecifier.h>
 #import "ModernSettingsViewController.h"
 
 @class T1SettingsViewController;
@@ -2146,12 +2144,6 @@ static void BHTApplyCopyButtonStyle(UIButton *copyButton, T1ProfileHeaderView *h
         batchSwizzlingOnClass([self class], [fontsMethods copy], (IMP)TAEStandardFontGroupReplacement);
     });
     return %orig;
-}
-%end
-
-%hook HBForceCepheiPrefs
-+ (BOOL)forceCepheiPrefsWhichIReallyNeedToAccessAndIKnowWhatImDoingISwear {
-    return YES;
 }
 %end
 


### PR DESCRIPTION
SettingsViewController was superseded by ModernSettingsViewController and had become dead code, but its Preferences.framework consumers were still being compiled and linked. Remove all traces:

- Drop PSListController and PSSpecifier imports from Tweak.x
- Remove HBForceCepheiPrefs hook from Tweak.x (no target once CepheiPrefs is unlinked)
- Drop SettingsViewController.h import from BHTManager.m
- Exclude SettingsViewController.m from build via filter-out in Makefile
- Remove BHTwitter_PRIVATE_FRAMEWORKS = Preferences from Makefile
- Remove BHTwitter_EXTRA_FRAMEWORKS (Cephei, CepheiPrefs, CepheiUI) from Makefile

BHTManager already reads all preferences via NSUserDefaults directly and BHTSettingsWithAccount: already returns ModernSettingsViewController, so no behaviour changes.

Assisted-by: Claude Sonnet 4.5 via Claude Code