### PR TITLE
fix(TweetsSettingsViewController): Add missing switchChanged: method

### DIFF
--- a/ModernSettingsViewController.m
+++ b/ModernSettingsViewController.m
@@ -1680,6 +1680,13 @@ static UIFont *TwitterChirpFont(TwitterFontStyle style) {
     return UITableViewAutomaticDimension;
 }
 
+- (void)switchChanged:(UISwitch *)sender {
+    NSString *key = objc_getAssociatedObject(sender, @"prefKey");
+    if (key) {
+        [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:key];
+    }
+}
+
 @end
 
 // ==============================


### PR DESCRIPTION
TweetsSettingsViewController registered switchChanged: as the UIControlEventValueChanged action for every toggle cell but never implemented the method, causing an unrecognized selector crash whenever any toggle in the Tweets settings screen was changed (e.g. 'Save tweet as image').

The method was present in all other section controllers (TwitterBlueSettingsViewController, MediaDownloadsSettingsViewController, ProfilesSettingsViewController, MessagesSettingsViewController) but was accidentally omitted from TweetsSettingsViewController during a prior cleanup refactor that removed the old_style toggle.

Assisted-by: Claude Sonnet 4 via Claude Code