### PR TITLE
Bypass age verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ concurrency:
 jobs:
   build:
     name: Build BHTwitter
-    runs-on: macos-14
+    runs-on: macos-latest
     permissions:
       contents: write
 

--- a/BHTManager.h
+++ b/BHTManager.h
@@ -34,6 +34,7 @@
 + (BOOL)DisableVODCaptions;
 + (BOOL)Padlock;
 + (BOOL)OldStyle;
++ (BOOL)bypassAgeVerification;
 + (BOOL)changeFont;
 + (BOOL)FLEX;
 + (BOOL)autoHighestLoad;
@@ -89,4 +90,3 @@
 + (BOOL)disableXChat;
 
 @end
-

--- a/BHTManager.m
+++ b/BHTManager.m
@@ -188,6 +188,9 @@
 + (BOOL)OldStyle {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"old_style"];
 }
++ (BOOL)bypassAgeVerification {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"bypass_age_verification"];
+}
 + (BOOL)changeFont {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"en_font"];
 }
@@ -384,4 +387,3 @@
 }
 
 @end
-

--- a/ModernSettingsViewController.m
+++ b/ModernSettingsViewController.m
@@ -1624,6 +1624,7 @@ static UIFont *TwitterChirpFont(TwitterFontStyle style) {
         @{ @"key": @"hide_view_count", @"titleKey": @"HIDE_VIEW_COUNT_OPTION_TITLE", @"subtitleKey": @"HIDE_VIEW_COUNT_OPTION_DETAIL_TITLE", @"default": @YES, @"type": @"toggle" },
         @{ @"key": @"hide_bookmark_button", @"titleKey": @"HIDE_MARKBOOK_BUTTON_OPTION_TITLE", @"subtitleKey": @"HIDE_MARKBOOK_BUTTON_OPTION_DETAIL_TITLE", @"default": @NO, @"type": @"toggle" },
         @{ @"key": @"disableSensitiveTweetWarnings", @"titleKey": @"DISABLE_SENSITIVE_TWEET_WARNINGS_OPTION_TITLE", @"subtitleKey": @"", @"default": @YES, @"type": @"toggle" },
+        @{ @"key": @"bypass_age_verification", @"titleKey": @"BYPASS_AGE_VERIFICATION_OPTION_TITLE", @"subtitleKey": @"BYPASS_AGE_VERIFICATION_OPTION_DETAIL_TITLE", @"default": @YES, @"type": @"toggle" },
         @{ @"key": @"hide_grok_analyze", @"titleKey": @"HIDE_GROK_ANALYZE_BUTTON_TITLE", @"subtitleKey": @"HIDE_GROK_ANALYZE_BUTTON_DETAIL_TITLE", @"default": @YES, @"type": @"toggle" },
         @{ @"key": @"reply_sorting_enabled", @"titleKey": @"REPLY_SORTING_TITLE", @"subtitleKey": @"REPLY_SORTING_DETAIL_TITLE", @"default": @NO, @"type": @"toggle" },
         @{ @"key": @"restore_reply_context", @"titleKey": @"RESTORE_REPLY_CONTEXT_TITLE", @"subtitleKey": @"RESTORE_REPLY_CONTEXT_DETAIL_TITLE", @"default": @YES, @"type": @"toggle" }

--- a/SettingsViewController.m
+++ b/SettingsViewController.m
@@ -428,6 +428,8 @@ PSSpecifier *photosVideosSection = [self newSectionWithTitle:[[BHTBundle sharedB
 
         PSSpecifier *disableSensitiveTweetWarnings = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"DISABLE_SENSITIVE_TWEET_WARNINGS_OPTION_TITLE"] detailTitle:nil key:@"disableSensitiveTweetWarnings" defaultValue:true changeAction:nil];
 
+        PSSpecifier *bypassAgeVerification = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"BYPASS_AGE_VERIFICATION_OPTION_TITLE"] detailTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"BYPASS_AGE_VERIFICATION_OPTION_DETAIL_TITLE"] key:@"bypass_age_verification" defaultValue:true changeAction:nil];
+
         PSSpecifier *copyProfileInfo = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"COPY_PROFILE_INFO_OPTION_TITLE"] detailTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"COPY_PROFILE_INFO_OPTION_DETAIL_TITLE"] key:@"CopyProfileInfo" defaultValue:false changeAction:nil];
 
         PSSpecifier *tweetToImage = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"TWEET_TO_IMAGE_OPTION_TITLE"] detailTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"TWEET_TO_IMAGE_OPTION_DETAIL_TITLE"] key:@"TweetToImage" defaultValue:false changeAction:nil];
@@ -602,6 +604,7 @@ PSSpecifier *photosVideosSection = [self newSectionWithTitle:[[BHTBundle sharedB
             hideViewCount,
             hideBookmarkButton,
             disableSensitiveTweetWarnings,
+            bypassAgeVerification,
             hideGrokAnalyze,
             squareAvatars,
             replySorting,

--- a/Tweak.x
+++ b/Tweak.x
@@ -472,6 +472,7 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"voice"];
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"undo_tweet"];
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"TrustedFriends"];
+        [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"bypass_age_verification"];
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"disableSensitiveTweetWarnings"];
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"disable_immersive_player"];
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"custom_voice_upload"];
@@ -1628,6 +1629,12 @@ static void BHTApplyCopyButtonStyle(UIButton *copyButton, T1ProfileHeaderView *h
         return true;
     }
 
+    if ([key hasPrefix:@"ios_age_assurance"] || [key isEqualToString:@"grok_settings_age_restriction_enabled"]) {
+        if ([BHTManager bypassAgeVerification]) {
+            return false;
+        }
+    }
+
     if ([key isEqualToString:@"subscriptions_upsells_get_verified_profile"] || [key isEqualToString:@"ios_profile_analytics_upsell_possible_enabled"] || [key isEqualToString:@"ios_profile_analytics_upsell_enabled"]) {
         return false;
     }
@@ -1707,7 +1714,7 @@ static void BHTApplyCopyButtonStyle(UIButton *copyButton, T1ProfileHeaderView *h
         }
         return YES;                       // default off when unset
     }
-    
+
     return %orig;
 }
 %end

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
@@ -129,6 +129,9 @@
 
 "DISABLE_SENSITIVE_TWEET_WARNINGS_OPTION_TITLE" = "No sensitive content warnings";
 
+"BYPASS_AGE_VERIFICATION_OPTION_TITLE" = "Bypass age verification";
+"BYPASS_AGE_VERIFICATION_OPTION_DETAIL_TITLE" = "Skips the age verification flow for sensitive content.";
+
 "HIDE_GROK_ANALYZE_BUTTON_TITLE" = "Hide Grok analyze buttons";
 "HIDE_GROK_ANALYZE_BUTTON_DETAIL_TITLE" = "Hides the Grok Analyze button in Tweets.";
 


### PR DESCRIPTION
Bypasses age verification in countries where you are prompted for ID to view sensitive media.

~~Also fixes a crash I was having on the latest version of Twitter (11.99) toggling Tweet settings.~~

EDIT: removed that since there's already a PR open for that fix to keep things clean

Example built IPA: https://github.com/theacrat/NeoFreeBird/actions/runs/27665520527